### PR TITLE
Use github.com/KyleBanks/goodreads

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/KyleBanks/goodreads-client
+module github.com/KyleBanks/goodreads
 
 require github.com/stretchr/testify v1.3.0


### PR DESCRIPTION
Currently, pulling into a Go module using `go get` results in `parsing go.mod: unexpected module path "github.com/KyleBanks/goodreads-client"`. This change fixes this by having the github path match the module name.